### PR TITLE
Use /usr/bin/env for crunchbang

### DIFF
--- a/MinIONQC.R
+++ b/MinIONQC.R
@@ -1,4 +1,4 @@
-#!/usr/bin/Rscript
+#!/usr/bin/env Rscript
 
 # MinIONQC version 1.3.5
 # Copyright (C) 2017 onwards Robert Lanfear


### PR DESCRIPTION
Uses #!/usr/bin/env Rscript as the crunchbang for MinionQC.R, in case R isn't installed to /usr/ as is the case on most clusters.