### PR TITLE
Fix Channel summary figure export to plot formats other than png

### DIFF
--- a/MinIONQC.R
+++ b/MinIONQC.R
@@ -609,7 +609,7 @@ single.flowcell <- function(input.file, output.dir, q=7, base.dir = NA){
         guides(fill=FALSE) +
         scale_fill_viridis(discrete = TRUE, begin = 0.25, end = 0.75) +
         guides(fill=FALSE)
-    suppressMessages(ggsave(filename = file.path(output.dir, "channel_summary.png"), device=plot_format, width = 960/75, height = 480/75, plot = p11)) 
+    suppressMessages(ggsave(filename = file.path(output.dir, paste("channel_summary.", plot_format, sep="")), device=plot_format, width = 960/75, height = 480/75, plot = p11)) 
     
 
     flog.info(paste(sep = "", flowcell, ": plotting physical overview of output per channel"))


### PR DESCRIPTION
This small PR adjusts the "channel_summary" figure file extension as this was not changed based on plot format.