### PR TITLE
Add one parameter to define the mux scan interval in some plots.

### DIFF
--- a/MinIONQC.R
+++ b/MinIONQC.R
@@ -81,6 +81,14 @@ parser <- add_option(parser,
                      default = 'png',
                      dest = 'plot_format',
                      help="A string in quotes, to set the output format of the plots. 'png' (the default) or any of 'pdf', 'ps', 'jpeg', 'tiff', 'bmp' are supported. 'png' is recommended and is thoroughly tested. The 'pdf' option may be useful if you have a system without X11 installed, because PNG files require X11 but PDF files do not. Other options are there for convenience."
+					 )
+
+parser <- add_option(parser, 
+					opt_str = c("-m", "--muxes"), 
+					type = "numeric",
+					default = '0',
+					dest = 'muxscan',
+					help="The value for mux scan used in MinKnow."
 )
 
 
@@ -441,7 +449,10 @@ single.flowcell <- function(input.file, output.dir, q=7, base.dir = NA){
     
     write(as.yaml(summary), out.txt)
     
-    muxes = seq(from = 0, to = max(d$hour), by = 8)
+    if (mux_int == 0) {
+    	mux_int = max(d$hour)
+    }
+    muxes = seq(from = 0, to = max(d$hour), by = mux_int)
 
     # set up variable sizes
     if(smallfig == TRUE){ p1m = 0.5 }else{ p1m = 1.0 }

--- a/MinIONQC.R
+++ b/MinIONQC.R
@@ -111,6 +111,7 @@ q = opt$q
 cores = opt$cores
 smallfig = opt$smallfig
 combined_only = opt$combined_only
+mux_int = opt$muxscan
 
 if (opt$plot_format %in% c('png', 'pdf', 'ps', 'jpeg', 'tiff', 'bmp')){
     plot_format = opt$plot_format


### PR DESCRIPTION
Because of mux scan interval is configurable in MinKnow, set it to 8 hours is not well adapted for every sequencing runs.
My idea is to propose the addition of one parameter (-m / --muxes) to allows to set the mux scan interval to a personalized value.
Set this value to a very little interval, will overload plots, so I decide to set the default value to zero. This choice allows to not display mux scans on plots.